### PR TITLE
feat: build with target wasm32-unknown-emscripten

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To build the WASM app instead, there are a few more setup steps.
 ### install the target architecture toolchain
 
 ```shell
-rustup target add asmjs-unknown-emscripten
+rustup target add wasm32-unknown-emscripten
 ```
 
 We use [emscripten](https://emscripten.org/) to convert Rust LLVM bytecode to WASM.
@@ -88,7 +88,7 @@ export EMCC_CFLAGS="-s USE_SDL=2"
 ### build
 
 ```shell
-cargo build --target asmjs-unknown-emscripten
+cargo build --target wasm32-unknown-emscripten
 ```
 
 Open the browser app with

--- a/index.html
+++ b/index.html
@@ -1,19 +1,29 @@
 <!DOCTYPE html>
 <html lang="en-us">
-<head><title>Emscripten-Generated Code</title></head>
+
+<head>
+    <title>Emscripten-Generated Code</title>
+</head>
+
 <body>
 
-<!-- The Module.canvas is where Emscripten renders our Rust game. -->
-<canvas id="canvas"></canvas>
+    <!-- The Module.canvas is where Emscripten renders our Rust game. -->
+    <canvas id="canvas"></canvas>
 
-<script type="text/javascript">
-    // a "var" named "Module" is required by Emscripten
-    // see: https://emscripten.org/docs/api_reference/module.html
-    var Module = {canvas: document.getElementById('canvas')};
-</script>
-
-<!-- This is the code compiled by emscripten. -->
-<script type="text/javascript" src="target/asmjs-unknown-emscripten/debug/hello-rust-sdl2-wasm.js"></script>
+    <script type="text/javascript">
+        // a "var" named "Module" is required by Emscripten
+        // see: https://emscripten.org/docs/api_reference/module.html
+        var Module = { canvas: document.getElementById('canvas') };
+        fetch('target/wasm32-unknown-emscripten/debug/hello_rust_sdl2_wasm.wasm')
+            .then((response) => response.arrayBuffer())
+            .then((buffer) => {
+                Module.wasmBinary = buffer
+                var script = document.createElement('script')
+                script.src = "target/wasm32-unknown-emscripten/debug/hello-rust-sdl2-wasm.js"
+                document.body.appendChild(script)
+            })
+    </script>
 
 </body>
+
 </html>

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,28 +13,26 @@ use hello_rust_sdl2_wasm::main_loop;
 //     cargo run
 
 // To build for the web:
-//     rustup target add asmjs-unknown-emscripten
+//     rustup target add wasm32-unknown-emscripten
 //     export EMCC_CFLAGS="-s USE_SDL=2"
-//     cargo build --target asmjs-unknown-emscripten && open index.html
+//     cargo build --target wasm32-unknown-emscripten && open index.html
 fn main() {
     let ctx = sdl2::init().unwrap();
     let video_ctx = ctx.video().unwrap();
 
-    let window  = match video_ctx
+    let window = match video_ctx
         .window("Hello, Rust / SDL2 / WASM!", 640, 480)
         .position_centered()
         .opengl()
-        .build() {
+        .build()
+    {
         Ok(window) => window,
-        Err(err)   => panic!("failed to create window: {}", err)
+        Err(err) => panic!("failed to create window: {}", err),
     };
 
-    let canvas = match window
-        .into_canvas()
-        .present_vsync()
-        .build() {
+    let canvas = match window.into_canvas().present_vsync().build() {
         Ok(canvas) => canvas,
-        Err(err) => panic!("failed to create canvas: {}", err)
+        Err(err) => panic!("failed to create canvas: {}", err),
     };
 
     let rect = Rect::new(0, 0, 10, 10);
@@ -47,7 +45,11 @@ fn main() {
     use hello_rust_sdl2_wasm::emscripten;
 
     #[cfg(target_family = "wasm")]
-    emscripten::set_main_loop_callback(main_loop(Rc::clone(&ctx), Rc::clone(&rect), Rc::clone(&canvas)));
+    emscripten::set_main_loop_callback(main_loop(
+        Rc::clone(&ctx),
+        Rc::clone(&rect),
+        Rc::clone(&canvas),
+    ));
 
     #[cfg(not(target_family = "wasm"))]
     {


### PR DESCRIPTION
I'm going to replace the target `asmjs-unknown-emscripten` with `wasm32-unknown-emscripten` because I cannot build with target `asmjs-unknown-emscripten` like this:

```
$ rustup target add asmjs-unknown-emscripten
error: toolchain 'nightly-aarch64-apple-darwin' does not support target 'asmjs-unknown-emscripten'; did you mean 'wasm32-unknown-emscripten'?
note: you can see a list of supported targets with `rustc --print=target-list`
note: if you are adding support for a new target to rustc itself, see https://rustc-dev-guide.rust-lang.org/building/new-target.html
```

The wasm-bindgen document also says that
```
The wasm-bindgen target does not support the wasm32-unknown-emscripten nor the asmjs-unknown-emscripten targets. 
```
https://rustwasm.github.io/wasm-bindgen/reference/rust-targets.html#other-web-targets
